### PR TITLE
fix: ensure repository owner is lowercase in Docker image tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,4 +24,4 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/job-tracker:latest
+          tags: ghcr.io/${{ github.repository_owner.lowercase() }}/job-tracker:latest


### PR DESCRIPTION
This pull request updates the Docker publishing workflow to ensure the repository owner is consistently referenced in lowercase format.

* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L27-R27): Modified the `tags` property to use `github.repository_owner.lowercase()` instead of `github.repository_owner` for consistent casing in the image tag.